### PR TITLE
Add Streamlit container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ spark-worker-stop: ## Stoppe le worker Spark
 # -- Services --
 
 start-services: ## Démarre les services
-	$(DOCKER) up -d scraper-bienici scraper-seloger scraper-gouv spark-job
+	$(DOCKER) up -d scraper-bienici scraper-seloger scraper-gouv spark-job streamlit
 
 stop-services: ## Stoppe les services
-	$(DOCKER) down -v scraper-bienici scraper-seloger scraper-gouv spark-job
+	$(DOCKER) down -v scraper-bienici scraper-seloger scraper-gouv spark-job streamlit
 
 # -- Composants individuels --
 
@@ -63,8 +63,11 @@ run-spark: ## Lance le job PySpark principal
 
 run-ui: ## Lance l'application Streamlit (UI)
 	@echo "▶ Démarrage de l’interface Streamlit..."
-	$(DOCKER) exec -it streamlit streamlit run streamlit_app/app.py
+	$(DOCKER) up -d streamlit
 
+streamlit-stop: ## Stoppe l'application Streamlit
+	$(DOCKER) down -v streamlit
+	
 # -- Nettoyage --
 
 clean: ## Nettoyage des fichiers générés (raw/processed/exports)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ T-DAT-902-HomePedia/
 make build        # Build toutes les images
 make start        # Lance tous les services (Attention : peut créer des problèmes entre les services)
 make stop         # Stoppe les services
-make run-ui       # Lance l'interface Streamlit
+make run-ui       # Démarre le conteneur Streamlit
+make streamlit-stop   # Arrête le conteneur Streamlit
 make clean-all    # Supprime les fichiers de données (data/)
 make seed-data    # Génère des données de test JSON
 make run-spark    # Exécute les jobs PySpark (recommendée après le scraping)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,20 @@ services:
           cpus: '2.0'
           memory: 2g
 
+  streamlit:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile-streamlit
+    container_name: streamlit
+    env_file:
+      - .env
+    ports:
+      - "8501:8501"
+    volumes:
+      - ./streamlit_app:/app/streamlit_app
+    networks:
+      - spark-network
+
 networks:
   spark-network:
     driver: bridge


### PR DESCRIPTION
## Summary
- add Streamlit service to docker compose
- extend makefile with Streamlit start/stop and update run-ui
- document new make commands in README

## Testing
- `docker compose config` *(fails: command not found)*
- `make help` *(fails: unterminated quoted string)*

------
https://chatgpt.com/codex/tasks/task_e_6855663728488333bc5bb13fd9d0469e