### PR TITLE
Add Postgres connection in streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,10 @@ L’interface Streamlit est disponible à l’adresse suivante une fois le proje
 ✅ Filtres interactifs, cartographies, nuages de mots
 
 ✅ Intégration PostgreSQL/Mongo + visualisation en direct
+
+## 🔌 Connexion PostgreSQL pour Streamlit
+
+La partie *streamlit_app* se connecte désormais directement à la base
+PostgreSQL. Configurez les variables `DB_HOST`, `DB_PORT`, `DB_NAME`,
+`DB_USER` et `DB_PASSWORD` (voir `.env.example`) avant de lancer
+l'interface pour accéder aux données.

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,10 +1,19 @@
 import streamlit as st
 from components.sidebar import show_sidebar
+from utils.db_connection import get_connection
 
 st.set_page_config(page_title="HomePedia", layout="wide")
 
 # Affichage de la sidebar personnalisée
 show_sidebar()
+
+# Tentative de connexion à la base PostgreSQL au démarrage de l'application
+try:
+    conn = get_connection()
+    conn.close()
+    st.sidebar.success("Connexion PostgreSQL établie")
+except Exception as e:
+    st.sidebar.error(f"Connexion PostgreSQL impossible : {e}")
 
 st.title("Bienvenue sur HomePedia 🏡")
 st.markdown("Explorez les dynamiques du marché immobilier français à travers des visualisations interactives.")

--- a/streamlit_app/pages/catalogue.py
+++ b/streamlit_app/pages/catalogue.py
@@ -1,0 +1,25 @@
+import streamlit as st
+import pandas as pd
+
+from components.sidebar import show_sidebar
+from utils.db_connection import load_data
+
+st.set_page_config(page_title="Catalogue", layout="wide")
+
+# Affichage des filtres dans la barre latérale
+filters = show_sidebar()
+
+st.title("Catalogue des annonces")
+
+# Tentative de chargement des données depuis PostgreSQL
+try:
+    df = load_data(filters)
+    st.success("Connexion PostgreSQL établie")
+except Exception as e:
+    st.error(f"Erreur lors de la connexion à PostgreSQL : {e}")
+    df = pd.DataFrame()
+
+if not df.empty:
+    st.dataframe(df.head(100), use_container_width=True)
+else:
+    st.info("Aucune donnée à afficher.")


### PR DESCRIPTION
## Summary
- display Postgres connection status in the main Streamlit app
- show catalogue page loading data from Postgres
- document Postgres configuration in README

## Testing
- `python3 -m py_compile streamlit_app/app.py streamlit_app/pages/catalogue.py`

------
https://chatgpt.com/codex/tasks/task_e_68556bb8961483338eeae8412f848ebb