### PR TITLE
Improve streamlit app config and add tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+exclude = .git,__pycache__,build,dist

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,13 @@ test-pyspark: ## Teste localement preprocessing Spark
 	python3 spark_jobs/preprocessing.py
 
 test-ui: ## Lance Streamlit localement hors Docker
-	streamlit run streamlit_app/app.py
+        streamlit run streamlit_app/app.py
+
+	lint: ## Exécute flake8 sur le projet
+	flake8 streamlit_app tests
+
+	test: ## Lance les tests unitaires
+	pytest -q
 
 # -- Meta --
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,7 @@ pandas>=2.2.3
 streamlit>=1.30
 streamlit-folium>=0.15
 folium>=0.15
+pytest>=8.0
+flake8>=7.0
 plotly>=5.20
 geopandas>=0.14

--- a/streamlit_app/components/sidebar.py
+++ b/streamlit_app/components/sidebar.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import datetime
 
@@ -6,15 +7,21 @@ def show_sidebar():
     st.sidebar.title("🧭 Filtres")
 
     # Filtres de base
-    city = st.sidebar.text_input("🏙️ Ville", "Paris")
+    default_city = os.getenv("DEFAULT_CITY", "Paris")
+    city = st.sidebar.text_input("🏙️ Ville", default_city)
     property_type = st.sidebar.selectbox("🏡 Type de bien", ["Tous", "Appartement", "Maison", "Studio", "Villa", "Loft"])
 
     # Plage de prix
     price_range = st.sidebar.slider("💶 Prix (en €)", 50000, 2000000, (100000, 800000), step=50000)
 
-    # Période
-    start_date = st.sidebar.date_input("📅 Début", datetime.date(2024, 1, 1))
-    end_date = st.sidebar.date_input("📅 Fin", datetime.date.today())
+    # Période dynamique sur 1 an
+    today = datetime.date.today()
+    default_start = today - datetime.timedelta(days=365)
+    start_date = st.sidebar.date_input("📅 Début", default_start)
+    end_date = st.sidebar.date_input("📅 Fin", today)
+
+    if start_date > end_date:
+        st.sidebar.error("La date de début doit être antérieure à la date de fin")
 
     st.sidebar.markdown("---")
     st.sidebar.info("Modifiez les filtres pour mettre à jour les visualisations")

--- a/streamlit_app/config.py
+++ b/streamlit_app/config.py
@@ -22,5 +22,14 @@ MONGO_CONFIG = {
     "password": os.getenv("MONGO_PASSWORD"),
 }
 # config.py
-MAPBOX_TOKEN = "your-mapbox-token"
-DATA_PATH = "data/"
+MAPBOX_TOKEN = os.getenv("MAPBOX_TOKEN")
+DATA_PATH = os.getenv("DATA_PATH", "data/")
+
+REQUIRED_VARS = ["host", "database", "user", "password"]
+missing = [v for v in REQUIRED_VARS if not POSTGRES_CONFIG.get(v)]
+if missing:
+    missing_str = ", ".join(missing)
+    raise ValueError(f"Missing PostgreSQL configuration variables: {missing_str}")
+
+if not MAPBOX_TOKEN:
+    raise ValueError("MAPBOX_TOKEN environment variable is not set")

--- a/streamlit_app/pages/analyse_descriptions.py
+++ b/streamlit_app/pages/analyse_descriptions.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+
+st.set_page_config(page_title="Analyse des Descriptions", layout="wide")
+
+st.title("📝 Analyse du contenu des annonces")
+st.write(
+    "Cette page présentera prochainement une analyse textuelle des descriptions d'annonces immobilières."
+)
+
+st.info("Fonctionnalité à venir")
+

--- a/streamlit_app/pages/carte_interactive.py
+++ b/streamlit_app/pages/carte_interactive.py
@@ -3,6 +3,7 @@ import folium
 from streamlit_folium import st_folium
 import pandas as pd
 import geopandas as gpd
+from config import DATA_PATH
 
 st.set_page_config(page_title="Carte Interactive", layout="wide")
 
@@ -11,8 +12,8 @@ st.title("🗺️ Carte Interactive du Marché Immobilier")
 # Chargement des données géographiques (GeoJSON ou shapefile converti)
 @st.cache_data
 def load_data():
-    gdf = gpd.read_file("data/departements.geojson")  # à adapter
-    df_indicateurs = pd.read_csv("data/indicateurs_immobilier.csv")  # à adapter
+    gdf = gpd.read_file(f"{DATA_PATH}/departements.geojson")
+    df_indicateurs = pd.read_csv(f"{DATA_PATH}/indicateurs_immobilier.csv")
     return gdf, df_indicateurs
 
 gdf, df_indicateurs = load_data()

--- a/streamlit_app/pages/catalogue.py
+++ b/streamlit_app/pages/catalogue.py
@@ -13,7 +13,8 @@ st.title("Catalogue des annonces")
 
 # Tentative de chargement des données depuis PostgreSQL
 try:
-    df = load_data(filters)
+    with st.spinner("Chargement des données..."):
+        df = load_data(filters)
     st.success("Connexion PostgreSQL établie")
 except Exception as e:
     st.error(f"Erreur lors de la connexion à PostgreSQL : {e}")

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from streamlit_app.utils.db_connection import build_query
+
+def test_build_query_no_filters():
+    query, params = build_query({})
+    assert 'WHERE 1=1' in query
+    assert 'LIMIT 1000' in query
+    assert params == []
+
+def test_build_query_with_filters():
+    filters = {
+        'city': 'Paris',
+        'property_type': 'Appartement',
+        'price_min': 100000,
+        'price_max': 200000,
+        'start_date': '2024-01-01',
+        'end_date': '2024-12-31'
+    }
+    query, params = build_query(filters)
+    assert 'LOWER(location) LIKE' in query
+    assert 'LOWER(property_type) = %s' in query
+    assert 'price BETWEEN %s AND %s' in query
+    assert 'scraped_at BETWEEN %s AND %s' in query
+    assert len(params) == 6


### PR DESCRIPTION
## Summary
- centralize configuration via environment variables and validation
- implement connection pooling, query builder and caching
- enhance sidebar defaults and validation
- add spinner and caching to pages
- add base page for descriptions
- add unit tests for query builder
- add flake8 config and tooling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `flake8 streamlit_app tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557635e48c83339f53ed669311821b