### PR TITLE
Fix interactive map data handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pdf
 *.json
 data
+!streamlit_app/data/
 .DS_Store
 
 bootstrap_data

--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ La partie *streamlit_app* se connecte désormais directement à la base
 PostgreSQL. Configurez les variables `DB_HOST`, `DB_PORT`, `DB_NAME`,
 `DB_USER` et `DB_PASSWORD` (voir `.env.example`) avant de lancer
 l'interface pour accéder aux données.
+
+### Données locales pour la carte interactive
+
+Certaines pages Streamlit utilisent des fichiers stockés en local,
+notamment `departements.geojson` et `indicateurs_immobilier.csv` pour la
+carte des départements. Par défaut, ces fichiers doivent se trouver dans
+le dossier `streamlit_app/data/`. Vous pouvez changer cet emplacement en
+définissant la variable d'environnement `DATA_PATH`.

--- a/streamlit_app/config.py
+++ b/streamlit_app/config.py
@@ -23,7 +23,10 @@ MONGO_CONFIG = {
 }
 # config.py
 MAPBOX_TOKEN = os.getenv("MAPBOX_TOKEN")
-DATA_PATH = os.getenv("DATA_PATH", "data/")
+# Path to local data used by Streamlit pages
+# Defaults to the `data` directory located inside the `streamlit_app` package
+DEFAULT_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
+DATA_PATH = os.getenv("DATA_PATH", DEFAULT_DATA_PATH)
 
 REQUIRED_VARS = ["host", "database", "user", "password"]
 missing = [v for v in REQUIRED_VARS if not POSTGRES_CONFIG.get(v)]

--- a/streamlit_app/pages/carte_interactive.py
+++ b/streamlit_app/pages/carte_interactive.py
@@ -4,6 +4,7 @@ from streamlit_folium import st_folium
 import pandas as pd
 import geopandas as gpd
 from config import DATA_PATH
+from pathlib import Path
 
 st.set_page_config(page_title="Carte Interactive", layout="wide")
 
@@ -12,8 +13,24 @@ st.title("🗺️ Carte Interactive du Marché Immobilier")
 # Chargement des données géographiques (GeoJSON ou shapefile converti)
 @st.cache_data
 def load_data():
-    gdf = gpd.read_file(f"{DATA_PATH}/departements.geojson")
-    df_indicateurs = pd.read_csv(f"{DATA_PATH}/indicateurs_immobilier.csv")
+    """Load geographic data and real estate indicators.
+
+    Display a Streamlit error if the files are missing instead of
+    raising an unhandled exception.
+    """
+    geo_path = Path(DATA_PATH) / "departements.geojson"
+    indic_path = Path(DATA_PATH) / "indicateurs_immobilier.csv"
+
+    if not geo_path.exists() or not indic_path.exists():
+        st.error(
+            f"Fichiers introuvables dans {DATA_PATH}. "
+            "Assurez-vous que 'departements.geojson' et "
+            "'indicateurs_immobilier.csv' sont présents."
+        )
+        st.stop()
+
+    gdf = gpd.read_file(geo_path)
+    df_indicateurs = pd.read_csv(indic_path)
     return gdf, df_indicateurs
 
 gdf, df_indicateurs = load_data()


### PR DESCRIPTION
## Summary
- set default data path inside `streamlit_app`
- handle missing map files gracefully
- document where to place local map data
- allow committing `streamlit_app/data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68557ab3f7388333be3a3b573dcbe9ab